### PR TITLE
Add locale-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Codex ERP Frontend
+
+This is a minimal ERP frontend scaffold built with Next.js App Router and Tailwind CSS. It demonstrates module-based routing, basic i18n setup with `next-intl`, and mocked service layers wrapped by React Query hooks.
+
+## Available Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build for production
+- `npm run start` – run the production build
+
+Ensure dependencies are installed with `npm install` before running the scripts.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  i18n: {
+    locales: ['tr', 'en'],
+    defaultLocale: 'tr',
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "codex-erp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-intl": "^2.10.0",
+    "@tanstack/react-query": "^5.29.0",
+    "clsx": "^2.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.15"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,20 @@
+{
+  "sales": "Sales",
+  "accounting": "Accounting",
+  "hr": "HR",
+  "createQuote": "Create New Quote",
+  "recentSales": "Recent Sales",
+  "revenue": "Revenue",
+  "profit": "Profit",
+  "employees": "Employees",
+  "user": "User",
+  "codexERP": "Codex ERP",
+  "customer": "Customer",
+  "amount": "Amount",
+  "date": "Date",
+  "department": "Department",
+  "inventory": "Inventory",
+  "production": "Production",
+  "projectManagement": "Project Management",
+  "welcome": "Welcome"
+}

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -1,0 +1,20 @@
+{
+  "sales": "Satış",
+  "accounting": "Muhasebe",
+  "hr": "İK",
+  "createQuote": "Yeni Teklif Oluştur",
+  "recentSales": "Son Satışlar",
+  "revenue": "Gelir",
+  "profit": "Kar",
+  "employees": "Çalışanlar",
+  "user": "Kullanıcı",
+  "codexERP": "Codex ERP",
+  "customer": "Müşteri",
+  "amount": "Tutar",
+  "date": "Tarih",
+  "department": "Departman",
+  "inventory": "Envanter",
+  "production": "Üretim",
+  "projectManagement": "Proje Yönetimi",
+  "welcome": "Hoşgeldiniz"
+}

--- a/src/app/[locale]/ProjectManagement/page.tsx
+++ b/src/app/[locale]/ProjectManagement/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+import {useTranslations} from 'next-intl';
+
+export default function ProjectManagementPage() {
+  const t = useTranslations();
+  return <div>{t('projectManagement')}</div>;
+}

--- a/src/app/[locale]/accounting/page.tsx
+++ b/src/app/[locale]/accounting/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Card from '../../../components/Card';
+import {useAccountingKpis} from '../../../services/accounting';
+import {useTranslations} from 'next-intl';
+
+export default function AccountingPage() {
+  const t = useTranslations();
+  const {data = []} = useAccountingKpis();
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {data.map((kpi) => (
+        <Card key={kpi.name} title={t(kpi.name)}>{kpi.value}</Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/[locale]/hr/page.tsx
+++ b/src/app/[locale]/hr/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import DataTable, {Column} from '../../../components/DataTable';
+import {useEmployees, Employee} from '../../../services/hr';
+import {useTranslations} from 'next-intl';
+
+export default function HrPage() {
+  const t = useTranslations();
+  const {data = []} = useEmployees();
+
+  const columns: Column<Employee>[] = [
+    {header: t('employees'), accessor: (e) => e.name},
+    {header: t('department'), accessor: (e) => e.department},
+  ];
+
+  return <DataTable columns={columns} data={data} keyField="id" />;
+}

--- a/src/app/[locale]/inventory/page.tsx
+++ b/src/app/[locale]/inventory/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+import {useTranslations} from 'next-intl';
+
+export default function InventoryPage() {
+  const t = useTranslations();
+  return <div>{t('inventory')}</div>;
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,65 @@
+import '../globals.css';
+import {ReactNode} from 'react';
+import Link from 'next-intl/link';
+import {unstable_setRequestLocale} from 'next-intl/server';
+import {NextIntlClientProvider, useTranslations} from 'next-intl';
+import {getMessages} from '../../i18n';
+import ReactQueryProvider from '../../providers/ReactQueryProvider';
+
+export const metadata = {
+  title: 'Codex ERP',
+};
+
+function Sidebar() {
+  const t = useTranslations();
+  return (
+    <aside className="w-60 bg-primary text-white p-4 space-y-2">
+      <div className="text-lg font-bold mb-4">{t('codexERP')}</div>
+      <nav className="space-y-2">
+        <Link href="/sales">{t('sales')}</Link>
+        <Link href="/accounting">{t('accounting')}</Link>
+        <Link href="/hr">{t('hr')}</Link>
+      </nav>
+    </aside>
+  );
+}
+
+function Header() {
+  const t = useTranslations();
+  return (
+    <header className="mb-6 border-b pb-4 flex justify-end">{t('user')}</header>
+  );
+}
+
+export default async function RootLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: {locale: string};
+}) {
+  unstable_setRequestLocale(params.locale);
+  const messages = await getMessages(params.locale);
+
+  return (
+    <html lang={params.locale}>
+      <body>
+        <NextIntlClientProvider locale={params.locale} messages={messages}>
+          <ReactQueryProvider>
+            <div className="min-h-screen flex">
+              <Sidebar />
+              <main className="flex-1 p-6">
+                <Header />
+                {children}
+              </main>
+            </div>
+          </ReactQueryProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}
+
+export function generateStaticParams() {
+  return [{locale: 'tr'}, {locale: 'en'}];
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+import {useTranslations} from 'next-intl';
+
+export default function HomePage() {
+  const t = useTranslations();
+  return <div>{t('welcome')}</div>;
+}

--- a/src/app/[locale]/production/page.tsx
+++ b/src/app/[locale]/production/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+import {useTranslations} from 'next-intl';
+
+export default function ProductionPage() {
+  const t = useTranslations();
+  return <div>{t('production')}</div>;
+}

--- a/src/app/[locale]/sales/layout.tsx
+++ b/src/app/[locale]/sales/layout.tsx
@@ -1,0 +1,12 @@
+import {ReactNode} from 'react';
+import {useTranslations} from 'next-intl';
+
+export default function SalesLayout({children}: {children: ReactNode}) {
+  const t = useTranslations();
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">{t('sales')}</h1>
+      {children}
+    </div>
+  );
+}

--- a/src/app/[locale]/sales/page.tsx
+++ b/src/app/[locale]/sales/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Button from '../../../components/Button';
+import DataTable, {Column} from '../../../components/DataTable';
+import {useRecentSales, Sale} from '../../../services/sales';
+import {useTranslations} from 'next-intl';
+
+export default function SalesPage() {
+  const t = useTranslations();
+  const {data = []} = useRecentSales();
+
+  const columns: Column<Sale>[] = [
+    {header: t('customer'), accessor: (s) => s.customer},
+    {header: t('amount'), accessor: (s) => s.amount},
+    {header: t('date'), accessor: (s) => s.date},
+  ];
+
+  return (
+    <div className="space-y-4">
+      <Button>{t('createQuote')}</Button>
+      <DataTable columns={columns} data={data} keyField="id" />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import {redirect} from 'next/navigation';
+
+export default function RootPage() {
+  redirect('/tr');
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,20 @@
+import {ButtonHTMLAttributes} from 'react';
+import clsx from 'clsx';
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary';
+};
+
+export default function Button({variant = 'primary', className, ...props}: ButtonProps) {
+  const variantClasses =
+    variant === 'primary'
+      ? 'bg-primary text-white hover:bg-primary-light'
+      : 'bg-secondary text-white hover:bg-secondary-light';
+
+  return (
+    <button
+      className={clsx('px-4 py-2 rounded font-semibold', variantClasses, className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,15 @@
+import {ReactNode} from 'react';
+
+export interface CardProps {
+  title: ReactNode;
+  children: ReactNode;
+}
+
+export default function Card({title, children}: CardProps) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <h3 className="text-sm font-medium mb-2 text-gray-600">{title}</h3>
+      <div className="text-2xl font-semibold text-gray-900">{children}</div>
+    </div>
+  );
+}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,39 @@
+import {ReactNode} from 'react';
+
+export type Column<T> = {
+  header: ReactNode;
+  accessor: (row: T) => ReactNode;
+};
+
+export interface DataTableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  keyField: keyof T;
+}
+
+export default function DataTable<T>({columns, data, keyField}: DataTableProps<T>) {
+  return (
+    <table className="min-w-full divide-y divide-gray-200 bg-white shadow">
+      <thead className="bg-gray-50">
+        <tr>
+          {columns.map((col, idx) => (
+            <th key={idx} className="px-4 py-2 text-left text-sm font-medium text-gray-700">
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-100">
+        {data.map((row) => (
+          <tr key={String(row[keyField])} className="hover:bg-gray-50">
+            {columns.map((col, idx) => (
+              <td key={idx} className="px-4 py-2 text-sm text-gray-800">
+                {col.accessor(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,9 @@
+export async function getMessages(locale: string) {
+  switch (locale) {
+    case 'en':
+      return (await import('../public/locales/en/common.json')).default;
+    case 'tr':
+    default:
+      return (await import('../public/locales/tr/common.json')).default;
+  }
+}

--- a/src/providers/ReactQueryProvider.tsx
+++ b/src/providers/ReactQueryProvider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {ReactNode, useState} from 'react';
+
+export default function ReactQueryProvider({children}: {children: ReactNode}) {
+  const [client] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -1,0 +1,17 @@
+import {useQuery} from '@tanstack/react-query';
+
+export interface Kpi {
+  name: string;
+  value: number;
+}
+
+export async function getAccountingKpis(): Promise<Kpi[]> {
+  return [
+    {name: 'revenue', value: 100000},
+    {name: 'profit', value: 25000},
+  ];
+}
+
+export function useAccountingKpis() {
+  return useQuery({queryKey: ['accountingKpis'], queryFn: getAccountingKpis});
+}

--- a/src/services/hr.ts
+++ b/src/services/hr.ts
@@ -1,0 +1,18 @@
+import {useQuery} from '@tanstack/react-query';
+
+export interface Employee {
+  id: number;
+  name: string;
+  department: string;
+}
+
+export async function getEmployees(): Promise<Employee[]> {
+  return [
+    {id: 1, name: 'Ahmet Yilmaz', department: 'Sales'},
+    {id: 2, name: 'Ayşe Kaya', department: 'Accounting'},
+  ];
+}
+
+export function useEmployees() {
+  return useQuery({queryKey: ['employees'], queryFn: getEmployees});
+}

--- a/src/services/sales.ts
+++ b/src/services/sales.ts
@@ -1,0 +1,19 @@
+import {useQuery} from '@tanstack/react-query';
+
+export interface Sale {
+  id: number;
+  customer: string;
+  amount: number;
+  date: string;
+}
+
+export async function getRecentSales(): Promise<Sale[]> {
+  return [
+    {id: 1, customer: 'Acme Corp', amount: 1200, date: '2024-05-01'},
+    {id: 2, customer: 'Beta Inc', amount: 850, date: '2024-05-02'},
+  ];
+}
+
+export function useRecentSales() {
+  return useQuery({queryKey: ['recentSales'], queryFn: getRecentSales});
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#004b8d',
+          light: '#1f6bb2',
+          dark: '#003567',
+        },
+        secondary: {
+          DEFAULT: '#e6a400',
+          light: '#ffbc38',
+          dark: '#b68100',
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- restructure `src/app` to use `[locale]` segment for Next.js i18n
- move module pages under `[locale]`
- update navigation links and import paths
- translate remaining UI text and add a root redirect page

## Testing
- `npm run lint` *(fails: `next` not found)*